### PR TITLE
Fix running `klipper` without log files

### DIFF
--- a/extras/ercf.py
+++ b/extras/ercf.py
@@ -429,8 +429,8 @@ class Ercf:
 
     def handle_connect(self):
         # Setup background file based logging before logging any messages
-        if self.logfile_level >= 0:
-            logfile_path = self.printer.start_args['log_file']
+        logfile_path = self.printer.start_args.get('log_file', None)
+        if self.logfile_level >= 0 and logfile_path:
             dirname = os.path.dirname(logfile_path)
             if dirname == None:
                 ercf_log = '/tmp/ercf.log'


### PR DESCRIPTION
If `klipper` is run without specifying log file, the `log_file` will not be existing. This checks and fallbacks to disable `logfile_level` instead of crashing with `KeyError`.

Just run bare bones klippy, to reproduce the problem:

```
python3 ~/klipper/klippy/klippy.py
```

```
Mar 22 19:15:47 voron0 python3[12471]: ERROR:root:Unhandled exception during connect
Mar 22 19:15:47 voron0 python3[12471]: Traceback (most recent call last):
Mar 22 19:15:47 voron0 python3[12471]:   File "/opt/klipper/klippy/klippy.py", line 180, in _connect
Mar 22 19:15:47 voron0 python3[12471]:     cb()
Mar 22 19:15:47 voron0 python3[12471]:   File "/opt/klipper/klippy/extras/ercf.py", line 433, in handle_connect
Mar 22 19:15:47 voron0 python3[12471]:     logfile_path = self.printer.start_args['log_file']
Mar 22 19:15:47 voron0 python3[12471]: KeyError: 'log_file'
```